### PR TITLE
Add/sidekiq health check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
       zeitwerk (~> 2.3)
     ast (2.4.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -103,6 +104,9 @@ GEM
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pry (0.14.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -200,6 +204,7 @@ DEPENDENCIES
   dotenv-rails
   hey_doctor!
   pg
+  pry
   redis
   rspec-rails
   rubocop-rails

--- a/app/services/hey_doctor/check_application_health_service.rb
+++ b/app/services/hey_doctor/check_application_health_service.rb
@@ -3,13 +3,13 @@
 class HeyDoctor::CheckApplicationHealthService
   class << self
     SUCCESS = {
-      message: 'Application is running',
-      success: true
+      success: true,
+      message: 'Application is running'
     }.freeze
 
     ERROR = {
-      message: 'Application down, call the firefighters',
-      success: false
+      success: false,
+      message: 'Application down, call the firefighters'
     }.freeze
 
     def call

--- a/app/services/hey_doctor/check_database_health_service.rb
+++ b/app/services/hey_doctor/check_database_health_service.rb
@@ -3,18 +3,18 @@
 class HeyDoctor::CheckDatabaseHealthService
   class << self
     SUCCESS = {
-      message: 'Database is connected',
-      success: true
+      success: true,
+      message: 'Database is connected'
     }.freeze
 
     MIGRATION_PENDING = {
-      message: 'Pending migrations detected',
-      success: true
+      success: true,
+      message: 'Pending migrations detected'
     }.freeze
 
     ERROR = {
-      message: 'Error connecting to database',
-      success: false
+      success: false,
+      message: 'Error connecting to database'
     }.freeze
 
     def call

--- a/app/services/hey_doctor/check_redis_health_service.rb
+++ b/app/services/hey_doctor/check_redis_health_service.rb
@@ -3,13 +3,13 @@
 class HeyDoctor::CheckRedisHealthService
   class << self
     SUCCESS = {
-      message: 'Redis is connected',
-      success: true
+      success: true,
+      message: 'Redis is connected'
     }.freeze
 
     ERROR = {
-      message: 'Error connecting to redis',
-      success: false
+      success: false,
+      message: 'Error connecting to redis'
     }.freeze
 
     def call

--- a/app/services/hey_doctor/check_sidekiq_health_service.rb
+++ b/app/services/hey_doctor/check_sidekiq_health_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class HeyDoctor::CheckSidekiqHealthService
+  class << self
+    SUCCESS = {
+      success: true,
+      message: 'Sidekiq is connected'
+    }.freeze
+
+    ERROR = {
+      success: false,
+      message: 'Error connecting to sidekiq'
+    }.freeze
+
+    NO_EXECUTOR = {
+      success: false,
+      message: 'None sidekiq host was found, add it to the ENV SIDEKIQ_HOSTS' \
+               ' listing your machine(s) ip or dns using  ; for each host'
+    }.freeze
+
+    def call
+      return NO_EXECUTOR if hosts.blank?
+
+      hosts.map { |host| response(host).merge({ host: host }) }
+    end
+
+    private
+
+    def hosts
+      @hosts ||= ENV['SIDEKIQ_HOSTS']&.split(';')
+    end
+
+    def response(host)
+      connected?(host) ? SUCCESS : ERROR
+    end
+
+    def connected?(host)
+      system("ping -c1 #{host}")
+    rescue StandardError
+      false
+    end
+  end
+end

--- a/hey_doctor.gemspec
+++ b/hey_doctor.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir['spec/**/*']
 
   spec.add_development_dependency 'dotenv-rails'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'redis'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rubocop-rails'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'pry'
 
   spec.required_ruby_version = '>= 2.5.3'
   spec.add_dependency 'mimemagic', '0.3.7'

--- a/hey_doctor.gemspec
+++ b/hey_doctor.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rubocop-rails'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'pry'
 
   spec.required_ruby_version = '>= 2.5.3'
   spec.add_dependency 'mimemagic', '0.3.7'

--- a/lib/hey_doctor.rb
+++ b/lib/hey_doctor.rb
@@ -21,6 +21,12 @@ module HeyDoctor::Rack
         response.merge!({ redis: ::HeyDoctor::CheckRedisHealthService.call })
       end
 
+      unless ENV['SIDEKIQ_HOSTS'].blank?
+        response.merge!(
+          { sidekiq: ::HeyDoctor::CheckSidekiqHealthService.call }
+        )
+      end
+
       response.to_json
     end
   end

--- a/spec/dummy/.env
+++ b/spec/dummy/.env
@@ -5,3 +5,5 @@ DATABASE_PASSWORD=passwd
 REDIS_URL=redis://redis:6379/1
 
 RAILS_PORT=8000
+
+SIDEKIQ_HOSTS=dcsiloifoodcatalogimporter_sidekiq_1;dcsiloifoodcatalogimporter_sidekiq_2

--- a/spec/dummy/.env
+++ b/spec/dummy/.env
@@ -6,4 +6,4 @@ REDIS_URL=redis://redis:6379/1
 
 RAILS_PORT=8000
 
-SIDEKIQ_HOSTS=dcsiloifoodcatalogimporter_sidekiq_1;dcsiloifoodcatalogimporter_sidekiq_2
+SIDEKIQ_HOSTS=sidekiq_host_1;sidekiq_host_2

--- a/spec/lib/hey_doctor/hey_doctor_spec.rb
+++ b/spec/lib/hey_doctor/hey_doctor_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe '.Rack HealthCheck endpoint' do
         {
           success: true,
           message: 'Sidekiq is connected',
-          host: 'dcsiloifoodcatalogimporter_sidekiq_1'
+          host: 'sidekiq_1'
         },
         {
           success: false,
-          message: 'Error connecting to sidekiq',
-          host: 'dcsiloifoodcatalogimporter_sidekiq_2'
+          message: 'Error sidekiq',
+          host: 'sidekiq_2'
         }
       ]
     }.to_json
@@ -36,13 +36,21 @@ RSpec.describe '.Rack HealthCheck endpoint' do
 
   before do
     allow(HeyDoctor::CheckApplicationHealthService).to receive(:call)
-      .and_return({ message: 'foo', success: true })
+      .and_return({ success: true, message: 'foo' })
 
     allow(HeyDoctor::CheckDatabaseHealthService).to receive(:call)
-      .and_return({ message: 'foo', success: true })
+      .and_return({ success: true, message: 'foo' })
 
     allow(HeyDoctor::CheckRedisHealthService).to receive(:call)
-      .and_return({ message: 'foo', success: true })
+      .and_return({ success: true, message: 'foo' })
+
+    allow(HeyDoctor::CheckSidekiqHealthService).to receive(:call)
+      .and_return(
+        [
+          { success: true, message: 'Sidekiq is connected', host: 'sidekiq_1' },
+          { success: false, message: 'Error sidekiq', host: 'sidekiq_2' }
+        ]
+      )
   end
 
   it 'build the json response' do

--- a/spec/lib/hey_doctor/hey_doctor_spec.rb
+++ b/spec/lib/hey_doctor/hey_doctor_spec.rb
@@ -6,17 +6,29 @@ RSpec.describe '.Rack HealthCheck endpoint' do
   let(:expected_response) do
     {
       app: {
-        message: 'foo',
-        success: true
+        success: true,
+        message: 'foo'
       },
       database: {
-        message: 'foo',
-        success: true
+        success: true,
+        message: 'foo'
       },
       redis: {
-        message: 'foo',
-        success: true
-      }
+        success: true,
+        message: 'foo'
+      },
+      sidekiq: [
+        {
+          success: true,
+          message: 'Sidekiq is connected',
+          host: 'dcsiloifoodcatalogimporter_sidekiq_1'
+        },
+        {
+          success: false,
+          message: 'Error connecting to sidekiq',
+          host: 'dcsiloifoodcatalogimporter_sidekiq_2'
+        }
+      ]
     }.to_json
   end
 

--- a/spec/services/hey_doctor/check_application_health_service_spec.rb
+++ b/spec/services/hey_doctor/check_application_health_service_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe HeyDoctor::CheckApplicationHealthService do
     context 'When app is running' do
       let(:expected_response) do
         {
-          message: 'Application is running',
-          success: true
+          success: true,
+          message: 'Application is running'
         }
       end
 
@@ -31,8 +31,8 @@ RSpec.describe HeyDoctor::CheckApplicationHealthService do
     context 'When app is down' do
       let(:expected_response) do
         {
-          message: 'Application down, call the firefighters',
-          success: false
+          success: false,
+          message: 'Application down, call the firefighters'
         }
       end
 

--- a/spec/services/hey_doctor/check_database_health_service_spec.rb
+++ b/spec/services/hey_doctor/check_database_health_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe HeyDoctor::CheckDatabaseHealthService do
     context 'when it is connected' do
       let(:expected_response) do
         {
-          message: 'Database is connected',
-          success: true
+          success: true,
+          message: 'Database is connected'
         }
       end
 
@@ -20,8 +20,8 @@ RSpec.describe HeyDoctor::CheckDatabaseHealthService do
     context 'when it is not connected' do
       let(:expected_response) do
         {
-          message: 'Error connecting to database',
-          success: false
+          success: false,
+          message: 'Error connecting to database'
         }
       end
 
@@ -38,8 +38,8 @@ RSpec.describe HeyDoctor::CheckDatabaseHealthService do
     context 'When migration is Pending' do
       let(:expected_response) do
         {
-          message: 'Pending migrations detected',
-          success: true
+          success: true,
+          message: 'Pending migrations detected'
         }
       end
 

--- a/spec/services/hey_doctor/check_redis_health_service_spec.rb
+++ b/spec/services/hey_doctor/check_redis_health_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe HeyDoctor::CheckRedisHealthService do
     context 'when it is connected' do
       let(:expected_response) do
         {
-          message: 'Redis is connected',
-          success: true
+          success: true,
+          message: 'Redis is connected'
         }
       end
 
@@ -20,8 +20,8 @@ RSpec.describe HeyDoctor::CheckRedisHealthService do
     context 'when it is not connected' do
       let(:expected_response) do
         {
-          message: 'Error connecting to redis',
-          success: false
+          success: false,
+          message: 'Error connecting to redis'
         }
       end
 

--- a/spec/services/hey_doctor/check_sidekiq_health_service_spec.rb
+++ b/spec/services/hey_doctor/check_sidekiq_health_service_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HeyDoctor::CheckSidekiqHealthService do
+  describe '.call' do
+    context 'when it is connected' do
+      let(:expected_response) do
+        [
+          {
+            success: true,
+            message: 'Sidekiq is connected',
+            host: 'dcsiloifoodcatalogimporter_sidekiq_1'
+          }
+        ]
+      end
+
+      before do
+        allow(described_class).to receive(:hosts)
+          .and_return(['dcsiloifoodcatalogimporter_sidekiq_1'])
+
+        allow(described_class).to receive(:connected?)
+          .with('dcsiloifoodcatalogimporter_sidekiq_1').and_return(true)
+      end
+
+      it 'respond with success' do
+        expect(described_class.call).to eq(expected_response)
+      end
+    end
+
+    context 'when it is not connected' do
+      let(:expected_response) do
+        [
+          {
+            success: false,
+            message: 'Error connecting to sidekiq',
+            host: 'dcsiloifoodcatalogimporter_sidekiq_2'
+          }
+        ]
+      end
+
+      before do
+        allow(described_class).to receive(:hosts)
+          .and_return(['dcsiloifoodcatalogimporter_sidekiq_2'])
+      end
+
+      it 'respond with error' do
+        expect(described_class.call).to eq(expected_response)
+      end
+    end
+  end
+
+  context 'when there is no executor machine' do
+    let(:expected_response) do
+      {
+        success: false,
+        message: 'None sidekiq host was found, add it to the ' \
+                 'ENV SIDEKIQ_HOSTS listing your machine(s) ip or' \
+                 ' dns using  ; for each host'
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:hosts).and_return(nil)
+    end
+
+    it 'respond with error' do
+      expect(described_class.call).to eq(expected_response)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'simplecov'
 require 'rack/test'
+require 'pry'
 
 SimpleCov.start 'rails' do
   add_filter '/bin'


### PR DESCRIPTION
**What is the content type?**

  - Feature

**Why is this change necessary?**

  - So we can check the health of Sidekiq executors.

**How does it address the issue?**

  - It pings all executor machines to perform the health check. Those executors urls or ips should be added to the env `SIDEKIQ_HOSTS` each one splited by `;`
  
**What side effects does this change have?**

  - none
  
**Does this change include database migrations? (If yes please list)**

   - none

**Link to a Jira Card?**

  - [[Debito Técnico] Monitorar sidekiq na gem hey_doctor](https://deliverycenterbr.atlassian.net/browse/SL-3169)

**Reviewers**

   - @deliverycenter/seller-backs
