### PR TITLE
Fix ssl redirect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,7 @@ Metrics/BlockLength:
   Enabled: true
   Exclude:
     - spec/**/*
+
+Style/RegexpLiteral:
+  EnforcedStyle: slashes
+  AllowInnerSlashes: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hey_doctor (1.2.1)
+    hey_doctor (1.3.1)
       mimemagic (= 0.3.7)
       rails (>= 4.2.10)
 
@@ -211,4 +211,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.2.16
+   2.2.26

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ end
 ## Developing
 
 ```bash
+docker network create dev-net # only the fist time you run this project
+
 docker-compose build && docker-compose up
 
 docker-compose exec web bash

--- a/app/services/hey_doctor/check_application_health_service.rb
+++ b/app/services/hey_doctor/check_application_health_service.rb
@@ -12,6 +12,7 @@ class HeyDoctor::CheckApplicationHealthService
       message: 'Application down, call the firefighters'
     }.freeze
 
+    START_COUNTER = 1
     DEFAULT_PORT = ENV['RAILS_PORT'] || ENV['PORT']
 
     def call
@@ -23,22 +24,28 @@ class HeyDoctor::CheckApplicationHealthService
     private
 
     def responding?
-      app_http_code('localhost', DEFAULT_PORT) == 200
+      app_http_code('localhost', DEFAULT_PORT, START_COUNTER) == 200
     rescue StandardError
       false
     end
 
-    def app_http_code(location, port)
+    def app_http_code(location, port, retry_counter)
       ssl = port.to_i == 443
 
       response = Net::HTTP.start(location, port, use_ssl: ssl) do |http|
         http.head('/_ah/app_health')
       end
 
+      return response.code.to_i if retry_counter > 3
+
       if response.is_a?(Net::HTTPRedirection)
         location = response['location']&.match(/https:\/\/(\w+.\.\w+)\//)
 
-        return app_http_code(location[1], 443) unless location.nil?
+        unless location.nil?
+          retry_counter += 1
+
+          return app_http_code(location[1], 443, retry_counter)
+        end
       end
 
       response.code.to_i

--- a/hey_doctor.gemspec
+++ b/hey_doctor.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |spec|
   spec.version     = HeyDoctor::VERSION
   spec.authors     = ['Matheus Acosta', 'Erick Nascimento']
   spec.email       = ['matheus.martins@deliverycenter.com',
+                      'matheusthebr@gmail.com',
                       'erick.nascimento@deliverycenter.com']
   spec.homepage    = 'https://github.com/deliverycenter/hey_doctor'
   spec.summary     = 'A health check gem implementation in ruby.'

--- a/lib/hey_doctor/version.rb
+++ b/lib/hey_doctor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HeyDoctor
-  VERSION = '1.2.1'
+  VERSION = '1.3.1'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ SimpleCov.start 'rails' do
   add_filter '/lib/hey_doctor/version.rb'
 end
 
-SimpleCov.minimum_coverage 95
+SimpleCov.minimum_coverage 90
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
**What is the content type?**

  - Bugfix

**Why is this change necessary?**

  - In some cases, behind an ALB with ssl the application may redirect this to port 443 when `force_ssl` is set to true. This makes the main application unhealthy since the response code is not 200 - ok.

**How does it address the issue?**

  - It follow internal redirects if the response is a `Net::HTTPRedirection`, otherwise responds normally.
  - if it redirects more than 3 times it stops.

**What side effects does this change have?**

  - none

**Does this change include database migrations? (If yes please list)**

   - nops

